### PR TITLE
(feat) container frame and shutdowns

### DIFF
--- a/components/entity.go
+++ b/components/entity.go
@@ -2,6 +2,7 @@ package components
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
@@ -132,7 +133,8 @@ func (v *EntityView) renderedContent() string {
 	}
 	renderer, err := glamour.NewTermRenderer(
 		glamour.WithStylesFromJSONBytes([]byte(mdStyles)),
-		glamour.WithWordWrap(v.width-2),
+		glamour.WithPreservedNewLines(),
+		glamour.WithWordWrap(int(math.Floor(float64(v.width)*0.95))),
 	)
 	if err != nil {
 		v.err = NewErrorView(err, v.styles)

--- a/components/frame.go
+++ b/components/frame.go
@@ -1,0 +1,41 @@
+package components
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+const FrameViewType = "frame"
+
+type FrameView struct {
+	model tea.Model
+}
+
+func (v *FrameView) Init() tea.Cmd {
+	return v.model.Init()
+}
+
+func (v *FrameView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	return v.model.Update(msg)
+}
+
+func (v *FrameView) View() string {
+	return v.model.View()
+}
+
+func (v *FrameView) HelpMsg() string {
+	return ""
+}
+
+func (v *FrameView) Interactive() bool {
+	return false
+}
+
+func (v *FrameView) Type() string {
+	return FrameViewType
+}
+
+func NewFrameView(model tea.Model) TeaModel {
+	return &FrameView{
+		model: model,
+	}
+}

--- a/components/markdown.go
+++ b/components/markdown.go
@@ -1,6 +1,7 @@
 package components
 
 import (
+	"math"
 	"os"
 
 	"github.com/charmbracelet/bubbles/viewport"
@@ -83,7 +84,8 @@ func (v *MarkdownView) View() string {
 	}
 	renderer, err := glamour.NewTermRenderer(
 		glamour.WithStylesFromJSONBytes([]byte(mdStyles)),
-		glamour.WithWordWrap(v.width-2),
+		glamour.WithPreservedNewLines(),
+		glamour.WithWordWrap(int(math.Floor(float64(v.width)*0.95))),
 	)
 	if err != nil {
 		v.err = NewErrorView(err, v.styles)

--- a/io/logger.go
+++ b/io/logger.go
@@ -100,7 +100,7 @@ func (l *StandardLogger) SetLevel(level int) {
 }
 
 func (l *StandardLogger) Print(data string) {
-	_, err := fmt.Fprint(l.stdOutFile, data)
+	_, err := fmt.Fprint(l.stdOutFile, ""+data)
 	if err != nil {
 		panic(err)
 	}
@@ -110,7 +110,7 @@ func (l *StandardLogger) Print(data string) {
 }
 
 func (l *StandardLogger) Println(data string) {
-	_, err := fmt.Fprintln(l.stdOutFile, data)
+	_, err := fmt.Fprintln(l.stdOutFile, ""+data)
 	if err != nil {
 		panic(err)
 	}
@@ -259,7 +259,7 @@ func (l *StandardLogger) PlainTextInfo(msg string) {
 	if l.stdOutHandler.GetLevel() > log.InfoLevel {
 		return
 	}
-	_, _ = fmt.Fprintln(l.stdOutFile, l.style.RenderInfo(msg))
+	_, _ = fmt.Fprintln(l.stdOutFile, ""+l.style.RenderInfo(msg))
 	if l.archiveFile != nil {
 		_, _ = fmt.Fprintln(l.archiveFile, msg)
 	}
@@ -269,17 +269,14 @@ func (l *StandardLogger) PlainTextSuccess(msg string) {
 	if l.stdOutHandler.GetLevel() > log.InfoLevel {
 		return
 	}
-	_, _ = fmt.Fprintln(l.stdOutFile, l.style.RenderSuccess(msg))
+	_, _ = fmt.Fprintln(l.stdOutFile, ""+l.style.RenderSuccess(msg))
 	if l.archiveFile != nil {
 		_, _ = fmt.Fprintln(l.archiveFile, msg)
 	}
 }
 
 func (l *StandardLogger) PlainTextError(msg string) {
-	if l.stdOutHandler.GetLevel() > log.InfoLevel {
-		return
-	}
-	_, _ = fmt.Fprintln(l.stdOutFile, l.style.RenderError(msg))
+	_, _ = fmt.Fprintln(l.stdOutFile, ""+l.style.RenderError(msg))
 	if l.archiveFile != nil {
 		_, _ = fmt.Fprintln(l.archiveFile, msg)
 	}
@@ -289,7 +286,7 @@ func (l *StandardLogger) PlainTextWarn(msg string) {
 	if l.stdOutHandler.GetLevel() > log.InfoLevel {
 		return
 	}
-	_, _ = fmt.Fprintln(l.stdOutFile, l.style.RenderWarning(msg))
+	_, _ = fmt.Fprintln(l.stdOutFile, ""+l.style.RenderWarning(msg))
 	if l.archiveFile != nil {
 		_, _ = fmt.Fprintln(l.archiveFile, msg)
 	}
@@ -299,7 +296,7 @@ func (l *StandardLogger) PlainTextDebug(msg string) {
 	if l.stdOutHandler.GetLevel() > log.DebugLevel {
 		return
 	}
-	_, _ = fmt.Fprintln(l.stdOutFile, l.style.RenderEmphasis(msg))
+	_, _ = fmt.Fprintln(l.stdOutFile, ""+l.style.RenderEmphasis(msg))
 	if l.archiveFile != nil {
 		_, _ = fmt.Fprintln(l.archiveFile, msg)
 	}

--- a/io/output.go
+++ b/io/output.go
@@ -11,6 +11,7 @@ type StdOutWriter struct {
 	LogMode   *LogMode
 }
 
+//nolint:dupl // this is a slightly modified mirror of StdErrWriter
 func (w StdOutWriter) Write(p []byte) (n int, err error) {
 	if strings.TrimSpace(string(p)) == "" {
 		return len(p), nil
@@ -50,6 +51,7 @@ type StdErrWriter struct {
 	LogMode   *LogMode
 }
 
+//nolint:dupl // this is a slightly modified mirror of StdOutWriter
 func (w StdErrWriter) Write(p []byte) (n int, err error) {
 	if strings.TrimSpace(string(p)) == "" {
 		return len(p), nil

--- a/types/collection.go
+++ b/types/collection.go
@@ -6,6 +6,7 @@ type CollectionItem struct {
 	Header    string
 	SubHeader string
 	Desc      string
+	ID        string
 }
 
 func (i *CollectionItem) Title() string {
@@ -17,7 +18,7 @@ func (i *CollectionItem) Title() string {
 }
 
 func (i *CollectionItem) Description() string { return i.Desc }
-func (i *CollectionItem) FilterValue() string { return i.Header }
+func (i *CollectionItem) FilterValue() string { return i.ID }
 
 type Collection interface {
 	Items() []*CollectionItem


### PR DESCRIPTION
# Summary

This commit introduces the Frame TeaModel type and a new method on the interactive container that can be used to shutdown the container. The shutdown is useful for run follow-up work after shutting down.

## Notable Changes

- Small fix for collection item filtering. Specifying an ID will make this more consistent. 
- New `FrameView` that just wraps a bubbletea model into the interactive container. Useful for run an existing program inside of the container framework.
- New `Shutdown()` method on the interactive container that kills the bubbletea program to free up the terminal output

## Change Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
