### PR TITLE
(fix) remove empty log lines and update err format

### DIFF
--- a/components/errors.go
+++ b/components/errors.go
@@ -2,6 +2,7 @@ package components
 
 import (
 	"fmt"
+	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -36,9 +37,7 @@ func (v *ErrorView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (v *ErrorView) View() string {
-	return v.styles.RenderError(
-		fmt.Errorf("!! encountered error !!\n%w\n\n", v.err).Error(), //nolint:stylecheck
-	)
+	return v.styles.RenderError(errorString(v.err))
 }
 
 func (v *ErrorView) HelpMsg() string {
@@ -51,4 +50,15 @@ func (v *ErrorView) Interactive() bool {
 
 func (v *ErrorView) Type() string {
 	return ErrorViewType
+}
+
+func errorString(err error) string {
+	errStr := "!! encountered error !!\n\n"
+	// split on `:` to print wrapped errors on new lines
+	// TODO: this is a hacky way to handle wrapped errors. Instead a defined error pattern should be enforced
+	parts := strings.Split(err.Error(), ":")
+	for _, part := range parts {
+		errStr += fmt.Sprintf("%s\n", part)
+	}
+	return errStr
 }

--- a/io/output.go
+++ b/io/output.go
@@ -23,6 +23,9 @@ func (w StdOutWriter) Write(p []byte) (n int, err error) {
 		w.Logger.SetMode(*w.LogMode)
 	}
 	for _, line := range splitP {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
 		switch w.Logger.LogMode() {
 		case Hidden:
 			return len(p), nil
@@ -63,6 +66,9 @@ func (w StdErrWriter) Write(p []byte) (n int, err error) {
 		w.Logger.SetMode(*w.LogMode)
 	}
 	for _, line := range splitP {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
 		switch w.Logger.LogMode() {
 		case Hidden:
 			return len(p), nil

--- a/io/output_test.go
+++ b/io/output_test.go
@@ -1,0 +1,124 @@
+package io_test
+
+import (
+	"testing"
+
+	"go.uber.org/mock/gomock"
+
+	"github.com/jahvon/tuikit/io"
+	"github.com/jahvon/tuikit/io/mocks"
+)
+
+func TestStdOutWriter_WriteText(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockLogger := mocks.NewMockLogger(ctrl)
+	writer := io.StdOutWriter{
+		Logger: mockLogger,
+	}
+
+	input := []byte("line 1\nline 2\nline 3\n")
+	mockLogger.EXPECT().LogMode().Return(io.Text).AnyTimes()
+	mockLogger.EXPECT().Println("line 1")
+	mockLogger.EXPECT().Println("line 2")
+	mockLogger.EXPECT().Println("line 3")
+
+	_, err := writer.Write(input)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+}
+
+func TestStdOutWriter_WriteLogFmt(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockLogger := mocks.NewMockLogger(ctrl)
+	fields := []interface{}{"key1", "value1", "key2", "value2"}
+	writer := io.StdOutWriter{
+		Logger:    mockLogger,
+		LogFields: fields,
+	}
+
+	input := []byte("line 1\nline 2\nline 3\nline 4")
+	mockLogger.EXPECT().LogMode().Return(io.Logfmt).AnyTimes()
+	mockLogger.EXPECT().Infox("line 1", fields...)
+	mockLogger.EXPECT().Infox("line 2", fields...)
+	mockLogger.EXPECT().Infox("line 3", fields...)
+	mockLogger.EXPECT().Infox("line 4", fields...)
+
+	_, err := writer.Write(input)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+}
+
+func TestStdOutWriter_WriteHidden(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockLogger := mocks.NewMockLogger(ctrl)
+	writer := io.StdOutWriter{
+		Logger: mockLogger,
+	}
+
+	input := []byte("line 1\nline 2\nline 3\n")
+	mockLogger.EXPECT().LogMode().Return(io.Hidden).AnyTimes()
+
+	_, err := writer.Write(input)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+}
+
+func TestStdErrWriter_WriteText(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockLogger := mocks.NewMockLogger(ctrl)
+	writer := io.StdErrWriter{
+		Logger: mockLogger,
+	}
+
+	input := []byte("line 1\nline 2\nline 3\n")
+	mockLogger.EXPECT().LogMode().Return(io.Text).AnyTimes()
+	mockLogger.EXPECT().PlainTextError("line 1")
+	mockLogger.EXPECT().PlainTextError("line 2")
+	mockLogger.EXPECT().PlainTextError("line 3")
+
+	_, err := writer.Write(input)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+}
+
+func TestStdErrWriter_WriteLogFmt(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockLogger := mocks.NewMockLogger(ctrl)
+	fields := []interface{}{"key1", "value1", "key2", "value2"}
+	writer := io.StdErrWriter{
+		Logger:    mockLogger,
+		LogFields: fields,
+	}
+
+	input := []byte("line 1\nline 2\nline 3\nline 4")
+	mockLogger.EXPECT().LogMode().Return(io.Logfmt).AnyTimes()
+	mockLogger.EXPECT().Errorx("line 1", fields...)
+	mockLogger.EXPECT().Errorx("line 2", fields...)
+	mockLogger.EXPECT().Errorx("line 3", fields...)
+	mockLogger.EXPECT().Errorx("line 4", fields...)
+
+	_, err := writer.Write(input)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+}
+
+func TestStdErrWriter_WriteHidden(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockLogger := mocks.NewMockLogger(ctrl)
+	writer := io.StdErrWriter{
+		Logger: mockLogger,
+	}
+
+	input := []byte("line 1\nline 2\nline 3\n")
+	mockLogger.EXPECT().LogMode().Return(io.Hidden).AnyTimes()
+
+	_, err := writer.Write(input)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
# Summary

Skips over printing empty lines in the log output and split wrapper error messages on new lines.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
